### PR TITLE
Added support for not saving options, get by name.

### DIFF
--- a/src/main/java/com/sanityinc/jargs/CmdLineParser.java
+++ b/src/main/java/com/sanityinc/jargs/CmdLineParser.java
@@ -451,13 +451,20 @@ public class CmdLineParser {
         return getOptionValue(o, null);
     }
 
+    /**
+     * Use instead of getOptionValue(Option) for when not saving the options.
+     */
+    public final <T> T getValue(String long_form) {
+        return getValue(long_form, null);
+    }
+
 
     /**
      * @return the parsed value of the given Option, or the given default 'def'
      * if the option was not set
      */
     public final <T> T getOptionValue( Option<T> o, T def ) {
-         List<?> v = values.get(o.longForm());
+        List<?> v = values.get(o.longForm());
 
         if (v == null) {
             return def;
@@ -474,6 +481,24 @@ public class CmdLineParser {
         }
     }
 
+    /**
+     * Use instead of getOptionValue(Option) for when not saving the options.
+     */
+    public final <T> T getValue(String long_form, T def) {
+        List<?> v = values.get(long_form);
+        if (v == null) {
+            return def;
+        } else if (v.isEmpty()) {
+            return null;
+        } else {
+            /*
+             * See above
+             */
+            @SuppressWarnings("unchecked")
+            T result = (T)v.remove(0);
+            return result;
+        }
+    }
 
     /**
      * @return A Collection giving the parsed values of all the occurrences of
@@ -493,6 +518,20 @@ public class CmdLineParser {
         }
     }
 
+    /**
+     * @return A Collection giving the parsed values of all the occurrences of
+     * the given Option, or an empty Collection if the option was not set.
+     */
+    public final <T> Collection<T> getValues(String long_form) {
+        Collection<T> vals = new ArrayList<T>();
+
+        T o = getValue(long_form, null);
+        while (o != null) {
+            vals.add(o);
+            o = getValue(long_form, null);
+        }
+        return vals;
+    }
 
     /**
      * @return the non-option arguments

--- a/src/test/java/com/sanityinc/jargs/CmdLineParserTestCase.java
+++ b/src/test/java/com/sanityinc/jargs/CmdLineParserTestCase.java
@@ -68,6 +68,30 @@ public class CmdLineParserTestCase {
         assertArrayEquals(new String[]{"rest"}, parser.getRemainingArgs());
     }
 
+    @Test
+    public void testStandardOptions_string() throws Exception {
+        CmdLineParser parser = new CmdLineParser();
+        Option<Boolean> verbose = parser.addBooleanOption('v', "verbose");
+        Option<Integer> size = parser.addIntegerOption('s', "size");
+        Option<String> name = parser.addStringOption('n', "name");
+        Option<Double> fraction = parser.addDoubleOption('f', "fraction");
+        Option<Boolean> missing = parser.addBooleanOption('m', "missing");
+        Option<Boolean> careful = parser.addBooleanOption("careful");
+        Option<Long> bignum = parser.addLongOption('b', "bignum");
+        assertEquals(null, parser.getOptionValue(size));
+        Long longValue = new Long(new Long(Integer.MAX_VALUE).longValue() + 1);
+        parser.parse(new String[] { "-v", "--size=100", "-b",
+                longValue.toString(), "-n", "foo", "-f", "0.1", "rest" },
+                Locale.US);
+        Boolean missed = parser.getValue("missing");
+        assertEquals(null, missed);
+        assertEquals(Boolean.TRUE, parser.getValue("verbose"));
+        assertEquals(100, ((Integer)parser.getValue("size")).intValue());
+        assertEquals("foo", parser.getValue("name"));
+        assertEquals(longValue, parser.getValue("bignum"));
+        assertEquals(0.1, ((Double)parser.getValue("fraction")).doubleValue(), 0.1e-6);
+        assertArrayEquals(new String[]{"rest"}, parser.getRemainingArgs());
+    }
 
     @Test
     public void testDefaults() throws Exception {


### PR DESCRIPTION
Motivation: I don't want to save all my options. I would rather just
get options by name. There for I added some methods:

```
<T> T getValue(String long_form)
<T> T getValue(String long_form, T default)
<T> Collection<T> getValues(String long_form)
```

They work the same way as getOptionValue(Option<T> o) etc...

A sanity test is written but more testing should probably be done.
